### PR TITLE
Fixed tests and add phpunit as a dev dependency in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
     ],
 
     "require-dev": {
-        "symfony/class-loader": "2.1.*"
+        "symfony/class-loader": "2.1.*",
+        "phpunit/phpunit": "^5.0"
     },
 
     "autoload": {

--- a/tests/Command/CommandFactory/FunctionCommandFactoryTest.php
+++ b/tests/Command/CommandFactory/FunctionCommandFactoryTest.php
@@ -15,70 +15,70 @@ use FormulaInterpreter\Command\CommandFactory\FunctionCommandFactory;
  * @author mathieu
  */
 class FunctionCommandFactoryTest extends PHPUnit_Framework_TestCase {
-    
+
     public function setUp() {
-        
-        $this->argumentCommandFactory = $this->getMock(
+
+        $this->argumentCommandFactory = $this->createMock(
             'FormulaInterpreter\Command\CommandFactory\CommandFactoryInterface'
         );
         $this->factory = new FunctionCommandFactory($this->argumentCommandFactory);
         $this->piFunction = function() {return 3.14;};
         $this->factory->registerFunction('pi', $this->piFunction);
     }
-    
+
     public function testCreateShouldReturnFunctionCommand() {
         $options = array('name' => 'pi');
         $object = $this->factory->create($options);
         $this->assertTrue($object instanceof FunctionCommand, 'An instance of FunctionCommand should be returned');
     }
-    
-    public function testCreateWithNoArguments() {       
+
+    public function testCreateWithNoArguments() {
         $options = array('name' => 'pi');
         $object = $this->factory->create($options);
-        $this->assertObjectPropertyEquals($object, 'callable', $this->piFunction);   
+        $this->assertObjectPropertyEquals($object, 'callable', $this->piFunction);
         $this->assertObjectPropertyEquals($object, 'argumentCommands', array());
     }
-    
-    public function testCreateWithArguments() {       
-        
-        $argumentCommand = $this->getMock(
+
+    public function testCreateWithArguments() {
+
+        $argumentCommand = $this->createMock(
             'FormulaInterpreter\Command\CommandInterface'
         );
         $this->argumentCommandFactory->expects($this->once())
                 ->method('create')
                 ->with($this->equalTo(array('type' => 'fake')))
                 ->will($this->returnValue($argumentCommand));
-        
+
         $options = array(
             'name' => 'pi',
             'arguments' => array(array('type' => 'fake'))
         );
         $object = $this->factory->create($options);
-        $this->assertObjectPropertyEquals($object, 'callable', $this->piFunction);   
+        $this->assertObjectPropertyEquals($object, 'callable', $this->piFunction);
         $this->assertObjectPropertyEquals($object, 'argumentCommands', array($argumentCommand));
     }
-    
+
     /**
      * @expectedException FormulaInterpreter\Exception\UnknownFunctionException
      */
-    public function testCreateWithNotExistingFunction() {       
-        
+    public function testCreateWithNotExistingFunction() {
+
         $options = array(
             'name' => 'notExistingFunction',
         );
         $this->factory->create($options);
     }
-    
+
     /**
      * @expectedException FormulaInterpreter\Command\CommandFactory\CommandFactoryException
      */
     public function testCreateWithMissingNameOption() {
         $this->factory->create(array());
     }
-        
+
     protected function assertObjectPropertyEquals($object, $property, $expected) {
         $this->assertEquals(PHPUnit_Framework_Assert::readAttribute($object, $property), $expected);
     }
-    
+
 }
 

--- a/tests/Command/CommandFactory/OperationCommandFactoryTest.php
+++ b/tests/Command/CommandFactory/OperationCommandFactoryTest.php
@@ -15,13 +15,13 @@ use FormulaInterpreter\Command\CommandFactory\OperationCommandFactory;
  * @author mathieu
  */
 class OperationCommandFactoryTest extends PHPUnit_Framework_TestCase {
-    
+
     public function setUp() {
         $this->factory = new OperationCommandFactory($this->createCommandFactoryMock());
     }
-    
+
     /**
-     * 
+     *
      */
     public function testCreateWithOneOperand() {
         $options = array(
@@ -29,9 +29,9 @@ class OperationCommandFactoryTest extends PHPUnit_Framework_TestCase {
         );
         $this->assertEquals($this->factory->create($options), new OperationCommand(new OperationCommandFactoryTest_FakeCommand(array(2))));
     }
-    
+
     /**
-     * 
+     *
      */
     public function testCreateWithEmptyOthersOperands() {
         $options = array(
@@ -43,55 +43,55 @@ class OperationCommandFactoryTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals($this->factory->create($options), new OperationCommand(new OperationCommandFactoryTest_FakeCommand(array(2))));
     }
 
-    
+
     /**
-     * 
+     *
      */
 
-     public function testCreateWithTwoOperands() { 
+     public function testCreateWithTwoOperands() {
         $options = array(
             'firstOperand' => array(2),
             'otherOperands' => array(
                 array('operator' => 'add', 'value' =>  array('3'))
             )
         );
-        
+
         $expected = new OperationCommand(new OperationCommandFactoryTest_FakeCommand(array(2)));
         $expected->addOperand('add', new OperationCommandFactoryTest_FakeCommand(array(3)));
-        
+
         $this->assertEquals($this->factory->create($options), $expected);
     }
-        
+
     /**
      * @expectedException FormulaInterpreter\Command\CommandFactory\CommandFactoryException
      */
     public function testCreateWithMissingFirstOperandOption() {
         $this->factory->create(array());
     }
-    
+
     protected function createCommandFactoryMock() {
-        
-        $operandFactory = $this->getMock('FormulaInterpreter\Command\CommandFactory\CommandFactoryInterface');
+
+        $operandFactory = $this->createMock('FormulaInterpreter\Command\CommandFactory\CommandFactoryInterface');
         $operandFactory->expects($this->any())
                 ->method('create')
                 ->will($this->returnCallback('OperationCommandFactoryTest::createFakeCommand'));
         return $operandFactory;
-        
+
     }
 
     static function createFakeCommand($options) {
         return new OperationCommandFactoryTest_FakeCommand($options);
     }
-    
+
 }
 
 class OperationCommandFactoryTest_FakeCommand implements CommandInterface {
-    
+
     protected $options;
-    
+
     function __construct($options) {
         $this->options = $options;
     }
-    
+
     public function run() {}
 }

--- a/tests/Command/CommandFactoryTest.php
+++ b/tests/Command/CommandFactoryTest.php
@@ -13,38 +13,38 @@ use FormulaInterpreter\Command\CommandFactory;
  * @author mathieu
  */
 class CommandFactoryTest extends PHPUnit_Framework_TestCase {
-    
+
     public function testCreate() {
         $factory = new CommandFactory();
-        
+
         $command = new CommandFactoryTest_FakeCommand();
-        $numericFactory = $this->getMock('\FormulaInterpreter\Command\CommandFactory');
+        $numericFactory = $this->createMock('\FormulaInterpreter\Command\CommandFactory');
         $numericFactory->expects($this->once())
                 ->method('create')
                 ->will($this->returnValue($command));
         $factory->registerFactory('numeric', $numericFactory);
-        
+
         $this->assertEquals($factory->create(array('type' => 'numeric')), $command);
     }
-    
+
     /**
      * @expectedException FormulaInterpreter\Command\CommandFactory\CommandFactoryException
      */
     public function testMissingTypeOption() {
         $factory = new CommandFactory();
-                
+
         $factory->create(array());
     }
-    
+
     /**
      * @expectedException FormulaInterpreter\Command\CommandFactory\CommandFactoryException
      */
     public function testUnknownType() {
         $factory = new CommandFactory();
-                
+
         $factory->create(array('type' => 'numeric'));
     }
-    
+
 }
 
 class CommandFactoryTest_FakeCommand implements \FormulaInterpreter\Command\CommandInterface {

--- a/tests/Command/FunctionCommandTest.php
+++ b/tests/Command/FunctionCommandTest.php
@@ -13,82 +13,82 @@ use FormulaInterpreter\Command\FunctionCommand;
  * @author mathieu
  */
 class FunctionCommandTest extends PHPUnit_Framework_TestCase {
-    
+
     public function testRunWithoutArguments() {
         $callable = function() {
           return 2;
         };
-        
+
         $command = new FunctionCommand($callable);
         $this->assertEquals($command->run(), 2);
-        
+
     }
-    
+
     public function testRunWithOneArgument() {
         $callable = function($arg) {
           return $arg;
         };
-        
-        $argumentCommand = $this->getMock('\FormulaInterpreter\Command\CommandInterface');
+
+        $argumentCommand = $this->createMock('\FormulaInterpreter\Command\CommandInterface');
         $argumentCommand->expects($this->once())
                 ->method('run')
                 ->will($this->returnValue(4));
         $command = new FunctionCommand($callable, array($argumentCommand));
-        
+
         $this->assertEquals($command->run(), 4);
-  
+
     }
-    
+
     public function testRunWithTwoArgument() {
         $callable = function($arg1, $arg2) {
           return $arg1 + $arg2;
         };
-        
+
         $argumentCommands = array();
         foreach (array(2, 3) as $value) {
-            $argumentCommand = $this->getMock('\FormulaInterpreter\Command\CommandInterface');
+            $argumentCommand = $this->createMock('\FormulaInterpreter\Command\CommandInterface');
             $argumentCommand->expects($this->any())
                     ->method('run')
                     ->will($this->returnValue($value));
             $argumentCommands[] = $argumentCommand;
         }
-        
+
         $command = new FunctionCommand($callable, $argumentCommands);
-        
+
         $this->assertEquals($command->run(), 5);
-  
+
     }
-    
+
     /**
      * @expectedException FormulaInterpreter\Exception\NotEnoughArgumentsException
      */
     public function testRunWithMissingArguments() {
         $callable = function($arg1) {};
-        
-        $command = new FunctionCommand($callable);  
+
+        $command = new FunctionCommand($callable);
     }
-    
+
     /**
      * @expectedException \InvalidArgumentException
      */
     public function testConstructWhenArgumentCommandDontImplementInterfaceCommand() {
         $callable = function($arg1) {};
-        
-        $command = new FunctionCommand($callable, array('whatever'));  
+
+        $command = new FunctionCommand($callable, array('whatever'));
     }
-    
+
     /**
      * @expectedException \InvalidArgumentException
      */
     public function testConstructWhenCallableParameterIsNotCallable() {
         $callable = 23;
-        
-        $command = new FunctionCommand($callable);  
+
+        $command = new FunctionCommand($callable);
     }
-    
 
 
-    
+
+
 }
 
 ?>

--- a/tests/Command/OperationCommandTest.php
+++ b/tests/Command/OperationCommandTest.php
@@ -13,103 +13,103 @@ use FormulaInterpreter\Command\OperationCommand;
  * @author mathieu
  */
 class OperationCommandTest extends PHPUnit_Framework_TestCase {
-    
+
     /**
      *
      */
     public function testRunWithOneOperand() {
-    
+
         $firstOperand = $this->createMockCommand(12);
-        
+
         $command = new OperationCommand($firstOperand);
-        
+
         $this->assertEquals($command->run(), 12);
     }
-    
+
     /**
      *
      */
     public function testRunWithAddition() {
-    
+
         $firstOperand = $this->createMockCommand(2);
         $command = new OperationCommand($firstOperand);
-        
+
         $operand = $this->createMockCommand(2);
         $command->addOperand(OperationCommand::ADD_OPERATOR, $operand);
-        
+
         $this->assertEquals($command->run(), 4);
     }
-    
+
     /**
      *
      */
     public function testRunWithMultplication() {
-    
+
         $firstOperand = $this->createMockCommand(3);
         $command = new OperationCommand($firstOperand);
-        
+
         $operand = $this->createMockCommand(2);
         $command->addOperand(OperationCommand::MULTIPLY_OPERATOR, $operand);
-        
+
         $this->assertEquals($command->run(), 6);
     }
-    
+
     /**
      *
      */
     public function testRunWithSubstraction() {
-    
+
         $firstOperand = $this->createMockCommand(2);
         $command = new OperationCommand($firstOperand);
-        
+
         $operand = $this->createMockCommand(1);
         $command->addOperand(OperationCommand::SUBTRACT_OPERATOR, $operand);
-        
+
         $this->assertEquals($command->run(), 1);
     }
-    
+
     /**
      *
      */
     public function testRunWithDivision() {
-    
+
         $firstOperand = $this->createMockCommand(6);
         $command = new OperationCommand($firstOperand);
-        
+
         $operand = $this->createMockCommand(2);
         $command->addOperand(OperationCommand::DIVIDE_OPERATOR, $operand);
-        
+
         $this->assertEquals($command->run(), 3);
-        
+
     }
-    
+
     /**
      *
      */
     public function testRunWithThreeOperands() {
-    
+
         $firstOperand = $this->createMockCommand(5);
         $command = new OperationCommand($firstOperand);
-        
+
         $operand = $this->createMockCommand(10);
         $command->addOperand(OperationCommand::ADD_OPERATOR, $operand);
-        
+
         $operand = $this->createMockCommand(1);
         $command->addOperand(OperationCommand::SUBTRACT_OPERATOR, $operand);
 
-        
+
         $this->assertEquals($command->run(), 14);
     }
-    
+
     public function createMockCommand($returnValue) {
-        $command = $this->getMock('FormulaInterpreter\Command\CommandInterface');
+        $command = $this->createMock('FormulaInterpreter\Command\CommandInterface');
         $command->expects($this->any())
             ->method('run')
             ->will($this->returnValue($returnValue));
         return $command;
     }
 
-    
+
 }
 
 ?>

--- a/tests/Command/VariableCommandTest.php
+++ b/tests/Command/VariableCommandTest.php
@@ -13,23 +13,23 @@ use FormulaInterpreter\Command\VariableCommand;
  * @author mathieu
  */
 class VariableCommandTest extends PHPUnit_Framework_TestCase {
-    
+
     /**
      * @dataProvider getData
      */
     public function testRunWhenVariablesExists($name, $variables, $result) {
         $command = new VariableCommand($name, $variables);
-        
+
         $this->assertEquals($command->run(), $result);
     }
-    
+
     public function getData() {
         return array(
             array('rate', array('rate' => 2), 2),
             array('price', array('price' => 32.2), 32.2),
         );
     }
-    
+
     /**
      * @expectedException FormulaInterpreter\Exception\UnknownVariableException
      */
@@ -37,9 +37,9 @@ class VariableCommandTest extends PHPUnit_Framework_TestCase {
         $command = new VariableCommand('rate', array());
         $command->run();
     }
-    
+
     public function testRunWhenVariablesHolderImplementsArrayAccess() {
-        $variables = $this->getMock('\ArrayAccess');
+        $variables = $this->createMock('\ArrayAccess');
         $variables->expects($this->any())
             ->method('offsetExists')
             ->with($this->equalTo('rate'))
@@ -48,12 +48,12 @@ class VariableCommandTest extends PHPUnit_Framework_TestCase {
             ->method('offsetGet')
             ->with($this->equalTo('rate'))
             ->will($this->returnValue(23));
-        
+
         $command = new VariableCommand('rate', $variables);
-        
+
         $this->assertEquals($command->run(), 23);
     }
-    
+
     /**
      * @expectedException \InvalidArgumentException
      * @dataProvider getIncorrectNames
@@ -61,7 +61,7 @@ class VariableCommandTest extends PHPUnit_Framework_TestCase {
     public function testInjectIncorrectName($name) {
         $command = new VariableCommand($name, array());
     }
-    
+
     public function getIncorrectNames() {
         return array(
             array(12),
@@ -70,7 +70,7 @@ class VariableCommandTest extends PHPUnit_Framework_TestCase {
             array(new StdClass()),
         );
     }
-    
+
     /**
      * @expectedException \InvalidArgumentException
      * @dataProvider getIncorrectVariables
@@ -78,7 +78,7 @@ class VariableCommandTest extends PHPUnit_Framework_TestCase {
     public function testInjectIncorrectVariables($variables) {
         $command = new VariableCommand('rate', $variables);
     }
-    
+
     public function getIncorrectVariables() {
         return array(
             array(12),
@@ -87,7 +87,7 @@ class VariableCommandTest extends PHPUnit_Framework_TestCase {
             array(new StdClass()),
         );
     }
-    
+
 }
 
 ?>

--- a/tests/Parser/FunctionParserTest.php
+++ b/tests/Parser/FunctionParserTest.php
@@ -13,27 +13,27 @@ use FormulaInterpreter\Parser\FunctionParser;
  * @author mathieu
  */
 class FunctionParserTest extends PHPUnit_Framework_TestCase {
-    
+
     public function setUp() {
-        $argumentParser = $this->getMock('\FormulaInterpreter\Parser\ParserInterface');
+        $argumentParser = $this->createMock('\FormulaInterpreter\Parser\ParserInterface');
         $argumentParser
             ->expects($this->any())
             ->method('parse')
             ->will($this->returnCallback(array($this, 'mockArgumentParser')));
         $this->parser = new FunctionParser($argumentParser);
-        
+
     }
-    
+
     /**
      * @dataProvider getCorrectExpressions
      */
     public function testParseWithCorrecrExpression($expression, $infos) {
-        
+
         $infos['type'] = 'function';
-        
+
         $this->assertEquals($this->parser->parse($expression), $infos);
     }
-    
+
     public function getCorrectExpressions() {
         return array(
             array('pi()', array('name' => 'pi')),
@@ -48,7 +48,7 @@ class FunctionParserTest extends PHPUnit_Framework_TestCase {
             array('max(sqrt(pow(2,4)),2)', array('name' => 'max', 'arguments' => array('sqrt(pow(2,4))', '2'))),
         );
     }
-    
+
     /**
      * @expectedException FormulaInterpreter\Parser\ParserException
      * @dataProvider getUncorrectExpressions
@@ -56,14 +56,14 @@ class FunctionParserTest extends PHPUnit_Framework_TestCase {
     public function testParseUncorrectExpression($expression) {
         $this->parser->parse($expression);
     }
-    
+
     public function getUncorrectExpressions() {
         return array(
             array(' what ever '),
             array(' what_ever( '),
         );
     }
-    
+
     public function mockArgumentParser($expression) {
         return $expression;
     }

--- a/tests/Parser/OperatorParserTest.php
+++ b/tests/Parser/OperatorParserTest.php
@@ -13,29 +13,29 @@ use FormulaInterpreter\Parser\OperatorParser;
  * @author mathieu
  */
 class OperatorParserTest extends PHPUnit_Framework_TestCase {
-    
+
     public function setUp() {
-        
-        $operandParser = $this->getMock('\FormulaInterpreter\Parser\ParserInterface');
+
+        $operandParser = $this->createMock('\FormulaInterpreter\Parser\ParserInterface');
         $operandParser
             ->expects($this->any())
             ->method('parse')
             ->will($this->returnCallback(array($this, 'mockOperandParser')));
-        
+
         $this->parser = new OperatorParser($operandParser);
     }
-    
+
     /**
      * @dataProvider getDataForTestingParse
      */
     public function testParse($expression, $infos) {
         $infos['type'] = 'operation';
-        
+
         $this->assertEquals($this->parser->parse($expression), $infos);
     }
-    
+
     public function getDataForTestingParse() {
-        
+
         return array(
             array('2+2', array(
                             'firstOperand' => '2',
@@ -101,7 +101,7 @@ class OperatorParserTest extends PHPUnit_Framework_TestCase {
                          )),
         );
     }
-    
+
     public function mockOperandParser($expression) {
         return $expression;
     }
@@ -113,7 +113,7 @@ class OperatorParserTest extends PHPUnit_Framework_TestCase {
     public function testParseUncorrectExpression($expression) {
         $this->parser->parse($expression);
     }
-    
+
     public function getUncorrectExpressions() {
         return array(
             array(' what ever '),
@@ -121,7 +121,7 @@ class OperatorParserTest extends PHPUnit_Framework_TestCase {
             array(' 2 + ()')
         );
     }
-    
+
 }
 
 ?>


### PR DESCRIPTION
Since PHPUnit 5.4 the ``The PHPUnit\Framework\TestCase::getMock()`` method has been deprecated. This PR will update all tests to use ``PHPUnit\Framework\TestCase::createMock()`` instead. Also, phpunit is added as a dev-dependency to the composer.json which makes it easier for developers to run tests after cloning the repo.